### PR TITLE
fix: do not scope `*` inside of `calc()` expressions

### DIFF
--- a/.changeset/chatty-masks-check.md
+++ b/.changeset/chatty-masks-check.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix CSS scoping of \* character inside of calc() expressions

--- a/internal/transform/scope-css.go
+++ b/internal/transform/scope-css.go
@@ -140,7 +140,7 @@ outer:
 						}
 						out += strVal
 					case "*":
-						if !isGlobal {
+						if parenCount == 0 && !isGlobal {
 							out += scopeRule("", opts) // turns "*" into ".astro-XXXXXX" rather than "*.astro-XXXXXX"
 						} else {
 							out += strVal

--- a/internal/transform/scope-css_test.go
+++ b/internal/transform/scope-css_test.go
@@ -189,6 +189,11 @@ func TestScopeStyle(t *testing.T) {
 			want:   "@keyframes shuffle{0%{transform:rotate(0deg);color:blue;}100%{transform:rotate(360deg};}}",
 		},
 		{
+			name:   "calc",
+			source: ":root{padding:calc(var(--space) * 2);}",
+			want:   ":root{padding:calc(var(--space) * 2);}",
+		},
+		{
 			name:   "charset",
 			source: "@charset \"utf-8\";",
 			want:   "@charset \"utf-8\";",


### PR DESCRIPTION
## Changes

- Closes https://github.com/snowpackjs/astro/issues/1942
- Updates our scoping approach to ignore `*` characters inside of functions.

## Testing

- Test added

## Docs

- Bug fix only
