### PR TITLE
fix: expressions inside of `<table>`

### DIFF
--- a/.changeset/spotty-buckets-accept.md
+++ b/.changeset/spotty-buckets-accept.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix behavior of expressions inside of <table> elements

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -1081,7 +1081,7 @@ func inBodyIM(p *parser) bool {
 			if p.oe.contains(a.Template) {
 				return true
 			}
-			if len(p.oe) >= 2 {
+			if len(p.oe) >= 1 {
 				body := p.oe[1]
 				if body.Type == ElementNode && body.DataAtom == a.Body {
 					p.framesetOK = false
@@ -1662,6 +1662,11 @@ func inTableIM(p *parser) bool {
 				return true
 			}
 		}
+	case StartExpressionToken:
+		p.addExpression()
+		p.setOriginalIM()
+		p.im = expressionIM
+		return true
 	case StartTagToken:
 		switch p.tok.DataAtom {
 		case a.Caption:
@@ -2493,6 +2498,8 @@ func expressionIM(p *parser) bool {
 				p.originalIM = inBodyIM
 				return false
 			}
+		} else if p.oe.contains(a.Table) {
+			return inTableBodyIM(p)
 		} else {
 			return inBodyIM(p)
 		}

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -313,7 +313,9 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 				p.printTemplateLiteralClose()
 			}
 		}
-		p.addSourceMapping(n.Loc[1])
+		if len(n.Loc) >= 2 {
+			p.addSourceMapping(n.Loc[1])
+		}
 		p.print("}")
 		return
 	}

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -1158,6 +1158,28 @@ const value = 'test';
 				code:        `<html><head></head><body><textarea>${value}</textarea></body></html>`,
 			},
 		},
+		{
+			name: "table expressions (no implicit tbody)",
+			source: `---
+const items = ["Dog", "Cat", "Platipus"];
+---
+<table>{items.map(item => (<tr><td>{item}</td></tr>))}</table>`,
+			want: want{
+				frontmatter: []string{"", `const items = ["Dog", "Cat", "Platipus"];`},
+				code:        `<html><head></head><body><table>${items.map(item => ($$render` + BACKTICK + `<tr><td>${item}</td></tr>` + BACKTICK + `))}</table></body></html>`,
+			},
+		},
+		{
+			name: "tbody expressions",
+			source: `---
+const items = ["Dog", "Cat", "Platipus"];
+---
+<table><tr><td>Name</td></tr>{items.map(item => (<tr><td>{item}</td></tr>))}</table>`,
+			want: want{
+				frontmatter: []string{"", `const items = ["Dog", "Cat", "Platipus"];`},
+				code:        `<html><head></head><body><table><tbody><tr><td>Name</td></tr>${items.map(item => ($$render` + BACKTICK + `<tr><td>${item}</td></tr>` + BACKTICK + `))}</tbody></table></body></html>`,
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Changes

- Closes https://github.com/snowpackjs/astro/issues/1939
- We weren't handling expressions inside of the `table` or `tbody` insertion modes, which was causing expressions to be fostered to another parent.
- This PR implements expression handling inside of the `table` and `tbody` insertion modes. Importantly (not reflected in original report) this change will not create an implicit `tbody` or `thead` if the only child of `table` is an expression.

## Testing

Tests added

## Docs

Bug fix only
