### PR TITLE
Fix `form > textarea` insertion mode

### DIFF
--- a/.changeset/brave-comics-rush.md
+++ b/.changeset/brave-comics-rush.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix edge case with with `textarea` inside of a Component when the document generated an implicit `head` tag

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -1069,6 +1069,17 @@ func inBodyIM(p *parser) bool {
 			p.framesetOK = false
 		}
 	case StartTagToken:
+		// It's possible we were moved here from inHeadIM
+		// via the children of a Component. We need to clear the originalIM
+		// and switch the implicit `head` tag to `body`
+		if p.originalIM != nil {
+			i := p.indexOfElementInScope(defaultScope, a.Head)
+			if i != -1 {
+				p.oe[i].Data = "body"
+				p.oe[i].DataAtom = a.Body
+				p.originalIM = nil
+			}
+		}
 		switch p.tok.DataAtom {
 		case a.Html:
 			if p.oe.contains(a.Template) {

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -1191,7 +1191,7 @@ const items = ["Dog", "Cat", "Platipus"];
 			name:   "textarea in form",
 			source: `<html><Component><form><textarea></textarea></form></Component></html>`,
 			want: want{
-				code: `<html>${$$renderComponent($$result,'Component',Component,{},{"default": () => $$render` + BACKTICK + `<form><textarea></textarea></form>` + BACKTICK + `})}</html>`,
+				code: `<html><body>${$$renderComponent($$result,'Component',Component,{},{"default": () => $$render` + BACKTICK + `<form><textarea></textarea></form>` + BACKTICK + `,})}</body></html>`,
 			},
 		},
 	}

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -1187,6 +1187,13 @@ const items = ["Dog", "Cat", "Platipus"];
 				code: `<html><head></head><body><img alt="A person saying &quot;hello&quot;"></body></html>`,
 			},
 		},
+		{
+			name:   "textarea in form",
+			source: `<html><Component><form><textarea></textarea></form></Component></html>`,
+			want: want{
+				code: `<html>${$$renderComponent($$result,'Component',Component,{},{"default": () => $$render` + BACKTICK + `<form><textarea></textarea></form>` + BACKTICK + `})}</html>`,
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Changes

- Closes https://github.com/snowpackjs/astro/issues/1953
- Added a failing test, then made sure it passed.
- Added a fix that reset the `originalIM` if we hit `StartTagToken` inside of `inBodyIM` when `originalIM != nil`. We now properly handle this edge case.

## Testing

Test added

## Docs

Bug fix only