### PR TITLE
Fix escaped entities

### DIFF
--- a/.changeset/good-eels-raise.md
+++ b/.changeset/good-eels-raise.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Encode double quotes inside of quoted attributes

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -221,7 +221,7 @@ func (p *printer) printAttribute(attr astro.Attribute) {
 		p.print(attr.Key)
 		p.print("=")
 		p.addSourceMapping(attr.ValLoc)
-		p.print(`"` + attr.Val + `"`)
+		p.print(`"` + encodeDoubleQuote(attr.Val) + `"`)
 	case astro.EmptyAttribute:
 		p.addSourceMapping(attr.KeyLoc)
 		p.print(attr.Key)

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -1178,6 +1178,13 @@ const items = ["Dog", "Cat", "Platipus"];
 			want: want{
 				frontmatter: []string{"", `const items = ["Dog", "Cat", "Platipus"];`},
 				code:        `<html><head></head><body><table><tbody><tr><td>Name</td></tr>${items.map(item => ($$render` + BACKTICK + `<tr><td>${item}</td></tr>` + BACKTICK + `))}</tbody></table></body></html>`,
+			}
+		},
+		{
+			name:   "escaped entity",
+			source: `<img alt="A person saying &#x22;hello&#x22;">`,
+			want: want{
+				code: `<html><head></head><body><img alt="A person saying &#x22;hello&#x22;"></body></html>`,
 			},
 		},
 	}

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -1178,7 +1178,7 @@ const items = ["Dog", "Cat", "Platipus"];
 			want: want{
 				frontmatter: []string{"", `const items = ["Dog", "Cat", "Platipus"];`},
 				code:        `<html><head></head><body><table><tbody><tr><td>Name</td></tr>${items.map(item => ($$render` + BACKTICK + `<tr><td>${item}</td></tr>` + BACKTICK + `))}</tbody></table></body></html>`,
-			}
+			},
 		},
 		{
 			name:   "escaped entity",

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -1184,7 +1184,7 @@ const items = ["Dog", "Cat", "Platipus"];
 			name:   "escaped entity",
 			source: `<img alt="A person saying &#x22;hello&#x22;">`,
 			want: want{
-				code: `<html><head></head><body><img alt="A person saying &#x22;hello&#x22;"></body></html>`,
+				code: `<html><head></head><body><img alt="A person saying &quot;hello&quot;"></body></html>`,
 			},
 		},
 	}

--- a/internal/printer/utils.go
+++ b/internal/printer/utils.go
@@ -31,3 +31,7 @@ func escapeBackticks(src string) string {
 func escapeSingleQuote(str string) string {
 	return strings.Replace(str, "'", "\\'", -1)
 }
+
+func encodeDoubleQuote(str string) string {
+	return strings.Replace(str, `"`, "&quot;", -1)
+}


### PR DESCRIPTION
## Changes

- Closes https://github.com/snowpackjs/astro/issues/1951
- Currently, attributes unescape entities, which is fine. We just weren't re-escaping `"` back to `&quot;` inside of attributes. Now we are!

## Testing

Test added

## Docs

Bug fix only
