### PR TITLE
fix: make all element checks case sensitive

### DIFF
--- a/.changeset/gorgeous-islands-hunt.md
+++ b/.changeset/gorgeous-islands-hunt.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix case-sensitivity of void elements

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -969,7 +969,7 @@ import { Container, Col, Row } from 'react-bootstrap';
 			want: want{
 				frontmatter: []string{`import { Container, Col, Row } from 'react-bootstrap';`},
 				metadata:    metadata{modules: []string{`{ module: $$module1, specifier: 'react-bootstrap' }`}},
-				code:        "${$$renderComponent($$result,'Container',Container,{},{\"default\": () => $$render`${$$renderComponent($$result,'Row',Row,{},{\"default\": () => $$render`${$$renderComponent($$result,'Col',Col,{})}<h1>Hi!</h1>`,})}`,})}\n.",
+				code:        "${$$renderComponent($$result,'Container',Container,{},{\"default\": () => $$render`${$$renderComponent($$result,'Row',Row,{},{\"default\": () => $$render`${$$renderComponent($$result,'Col',Col,{},{\"default\": () => $$render`<h1>Hi!</h1>`,})}`,})}`,})}",
 			},
 		},
 		{
@@ -1192,6 +1192,13 @@ const items = ["Dog", "Cat", "Platipus"];
 			source: `<html><Component><form><textarea></textarea></form></Component></html>`,
 			want: want{
 				code: `<html><body>${$$renderComponent($$result,'Component',Component,{},{"default": () => $$render` + BACKTICK + `<form><textarea></textarea></form>` + BACKTICK + `,})}</body></html>`,
+			},
+		},
+		{
+			name:   "slot inside of Base",
+			source: `<Base title="Home"><div>Hello</div></Base>`,
+			want: want{
+				code: `${$$renderComponent($$result,'Base',Base,{"title":"Home"},{"default": () => $$render` + BACKTICK + `<div>Hello</div>` + BACKTICK + `,})}`,
 			},
 		},
 	}

--- a/internal/token.go
+++ b/internal/token.go
@@ -915,9 +915,6 @@ loop:
 		}
 		for i := 0; i < len(s); i++ {
 			c := z.buf[z.data.Start+i]
-			if 'A' <= c && c <= 'Z' {
-				c += 'a' - 'A'
-			}
 			if c != s[i] {
 				continue loop
 			}
@@ -935,9 +932,6 @@ loop:
 		key := z.buf[x[0].Start:x[0].End]
 		for i := 0; i < len(key) && i < len(s); i++ {
 			c := key[i]
-			if 'A' <= c && c <= 'Z' {
-				c += 'a' - 'A'
-			}
 			if c != s[i] {
 				continue loop
 			}
@@ -953,9 +947,6 @@ func (z *Tokenizer) readStartTag() TokenType {
 	z.readTag(true)
 	// Several tags flag the tokenizer's next token as raw.
 	c, raw := z.buf[z.data.Start], false
-	if 'A' <= c && c <= 'Z' {
-		c += 'a' - 'A'
-	}
 	switch c {
 	case 'i':
 		raw = z.startTagIn("iframe")
@@ -1816,7 +1807,9 @@ func (z *Tokenizer) Token() Token {
 			key, keyLoc, val, valLoc, attrType, moreAttr = z.TagAttr()
 			t.Attr = append(t.Attr, Attribute{"", atom.String(key), keyLoc, string(val), valLoc, attrTokenizer, attrType})
 		}
-		if a := atom.Lookup(name); a != 0 {
+		if isFragment(string(name)) || isComponent(string(name)) {
+			t.DataAtom, t.Data = 0, string(name)
+		} else if a := atom.Lookup(name); a != 0 {
 			t.DataAtom, t.Data = a, a.String()
 		} else {
 			t.DataAtom, t.Data = 0, string(name)


### PR DESCRIPTION
## Changes

- Closes https://github.com/snowpackjs/astro/issues/1974
- Turns out not all of our tag checks were case-sensitive, so `Base` was being treated as a void tag (`base`).
- This fixes the case-sensitivity of the tokenizer.

## Testing

Test added. Test that _was_ passing but should have been failing updated to reflect the correct behavior.

## Docs

Bug fix only.