### PR TITLE
Fix issue where components can only add one style or script

### DIFF
--- a/.changeset/dirty-starfishes-bake.md
+++ b/.changeset/dirty-starfishes-bake.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fixed issue where an Astro Components could only add one style or script

--- a/internal/printer/print-to-js.go
+++ b/internal/printer/print-to-js.go
@@ -182,7 +182,7 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 					}
 					p.println("];")
 					p.addNilSourceMapping()
-					p.println(fmt.Sprintf("%s.styles.add(...STYLES);", RESULT))
+					p.println(fmt.Sprintf("for (const STYLE of STYLES) %s.styles.add(STYLE));", RESULT))
 				}
 
 				if len(n.Parent.Scripts) > 0 {
@@ -192,7 +192,7 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 					}
 					p.println("];")
 					p.addNilSourceMapping()
-					p.println(fmt.Sprintf("%s.scripts.add(...SCRIPTS);", RESULT))
+					p.println(fmt.Sprintf("for (const SCRIPT of SCRIPTS) %s.scripts.add(SCRIPT));", RESULT))
 				}
 
 				p.printReturnOpen()
@@ -224,7 +224,7 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 			}
 			p.println("];")
 			p.addNilSourceMapping()
-			p.println(fmt.Sprintf("%s.styles.add(...STYLES);", RESULT))
+			p.println(fmt.Sprintf("for (const STYLE of STYLES) %s.styles.add(STYLE));", RESULT))
 		}
 		if len(n.Parent.Scripts) > 0 {
 			p.println("const SCRIPTS = [")
@@ -233,7 +233,7 @@ func render1(p *printer, n *Node, opts RenderOptions) {
 			}
 			p.println("];")
 			p.addNilSourceMapping()
-			p.println(fmt.Sprintf("%s.scripts.add(...SCRIPTS);", RESULT))
+			p.println(fmt.Sprintf("for (const SCRIPT of SCRIPTS) %s.scripts.add(SCRIPT));", RESULT))
 		}
 
 		p.printReturnOpen()

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -36,7 +36,7 @@ export default $$Component;`
 var STYLE_PRELUDE = "const STYLES = [\n"
 var STYLE_SUFFIX = "];\nfor (const STYLE of STYLES) $$result.styles.add(STYLE));\n"
 var SCRIPT_PRELUDE = "const SCRIPTS = [\n"
-var SCRIPT_SUFFIX = "];\nfor (const SCRIPT of SCRIPTS) $$result.scripts.add(STYLE));\n"
+var SCRIPT_SUFFIX = "];\nfor (const SCRIPT of SCRIPTS) $$result.scripts.add(SCRIPT));\n"
 var CREATE_ASTRO_CALL = "const $$Astro = $$createAstro(import.meta.url, 'https://astro.build');\nconst Astro = $$Astro;"
 
 // SPECIAL TEST FIXTURES

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -34,9 +34,9 @@ var SUFFIX = fmt.Sprintf("%s;", BACKTICK) + `
 });
 export default $$Component;`
 var STYLE_PRELUDE = "const STYLES = [\n"
-var STYLE_SUFFIX = "];\n$$result.styles.add(...STYLES);\n"
+var STYLE_SUFFIX = "];\nfor (const STYLE of STYLES) $$result.styles.add(STYLE));\n"
 var SCRIPT_PRELUDE = "const SCRIPTS = [\n"
-var SCRIPT_SUFFIX = "];\n$$result.scripts.add(...SCRIPTS);\n"
+var SCRIPT_SUFFIX = "];\nfor (const SCRIPT of SCRIPTS) $$result.scripts.add(STYLE));\n"
 var CREATE_ASTRO_CALL = "const $$Astro = $$createAstro(import.meta.url, 'https://astro.build');\nconst Astro = $$Astro;"
 
 // SPECIAL TEST FIXTURES


### PR DESCRIPTION
## Changes

- Fixes issue where only one script or style may be added from an Astro component.
  - **Reason**: Astro Compiler spreads arguments to `Set#add` which takes one argument and not a spread.
  - **Solution**: Iterate scripts or styles and add them individually to their respective set.

## Testing

Tests are updated in `printer_test.go`

I would love to learn how I could write a specific test that would have caught this issue.

## Docs

bug fix only
