### PR TITLE
Support expressions in SVG elements

### DIFF
--- a/.changeset/perfect-terms-rush.md
+++ b/.changeset/perfect-terms-rush.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fixed issue where expressions did not work within SVG elements

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -2533,7 +2533,6 @@ func ignoreTheRemainingTokens(p *parser) bool {
 
 const whitespaceOrNUL = whitespace + "\x00"
 
-// TODO: handle expressions in SVG
 // Section 12.2.6.5
 func parseForeignContent(p *parser) bool {
 	switch p.tok.Type {

--- a/internal/parser.go
+++ b/internal/parser.go
@@ -2612,6 +2612,14 @@ func parseForeignContent(p *parser) bool {
 			}
 		}
 		return true
+	case StartExpressionToken:
+		p.reconstructActiveFormattingElements()
+		p.addExpression()
+		return true
+	case EndExpressionToken:
+		p.addLoc()
+		p.oe.pop()
+		return true
 	default:
 		// Ignore the token.
 	}

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -862,6 +862,17 @@ const title = 'icon';
 			},
 		},
 		{
+			name: "advanced svg expression",
+			source: `---
+const title = 'icon';
+---
+<svg>{title ? <title>{title}</title> : null}</svg>`,
+			want: want{
+				frontmatter: []string{"", "const title = 'icon';"},
+				code:        `<html><head></head><body><svg>${title ? $$render` + BACKTICK + `<title>${title}</title>` + BACKTICK + ` : null}</svg></body></html>`,
+			},
+		},
+		{
 			name:   "Empty script",
 			source: `<script hoist></script>`,
 			want: want{

--- a/internal/printer/printer_test.go
+++ b/internal/printer/printer_test.go
@@ -851,6 +851,17 @@ import ZComponent from '../components/ZComponent.jsx';`},
 			},
 		},
 		{
+			name: "svg expressions",
+			source: `---
+const title = 'icon';
+---
+<svg>{title ?? null}</svg>`,
+			want: want{
+				frontmatter: []string{"", "const title = 'icon';"},
+				code:        `<html><head></head><body><svg>${title ?? null}</svg></body></html>`,
+			},
+		},
+		{
 			name:   "Empty script",
 			source: `<script hoist></script>`,
 			want: want{


### PR DESCRIPTION
## Changes

- Fixes an issue where expressions did not work within SVG elements.
- Follows behavior of `inBodyIM`.

## Testing

- added simple test — `<svg>{title ?? null}</svg>`.
- added nested test — `<svg>{title ? <title>{title}</title> : null}</svg>`.

## Docs

bug fix only