### PR TITLE
fix: handle empty preprocessed style

### DIFF
--- a/.changeset/short-chairs-attack.md
+++ b/.changeset/short-chairs-attack.md
@@ -1,0 +1,5 @@
+---
+'@astrojs/compiler': patch
+---
+
+Fix panic when preprocessed style is empty

--- a/cmd/astro-wasm/astro-wasm.go
+++ b/cmd/astro-wasm/astro-wasm.go
@@ -90,6 +90,9 @@ type TransformResult struct {
 // This is spawned as a goroutine to preprocess style nodes using an async function passed from JS
 func preprocessStyle(i int, style *astro.Node, transformOptions transform.TransformOptions, cb func()) {
 	defer cb()
+	if style.FirstChild == nil {
+		return
+	}
 	attrs := wasm_utils.GetAttrs(style)
 	data, _ := wasm_utils.Await(transformOptions.PreprocessStyle.(js.Value).Invoke(style.FirstChild.Data, attrs))
 	// note: Rollup (and by extension our Astro Vite plugin) allows for "undefined" and "null" responses if a transform wishes to skip this occurrence

--- a/lib/compiler/test/empty-style.test.mjs
+++ b/lib/compiler/test/empty-style.test.mjs
@@ -1,0 +1,50 @@
+import { transform } from '@astrojs/compiler';
+import sass from 'sass';
+
+function transformSass(value) {
+  return new Promise((resolve, reject) => {
+    sass.render({ data: value }, (err, result) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve({ code: result.css.toString('utf8'), map: result.map });
+      return;
+    });
+  });
+}
+
+async function run() {
+  const result = await transform(
+    `---
+let value = 'world';
+---
+
+<style lang="scss"></style>
+
+<div>Hello world!</div>
+
+<div>Ahhh</div>
+`,
+    {
+      sourcemap: true,
+      preprocessStyle: async (value, attrs) => {
+        if (!attrs.lang) {
+          return null;
+        }
+        if (attrs.lang === 'scss') {
+          try {
+            return transformSass(value);
+          } catch (err) {
+            console.error(err);
+          }
+        }
+        return null;
+      },
+    }
+  );
+
+  console.log(result);
+}
+
+await run();

--- a/lib/compiler/test/test.mjs
+++ b/lib/compiler/test/test.mjs
@@ -1,2 +1,3 @@
 import './basic.test.mjs';
+import './empty-style.test.mjs';
 import './output.test.mjs';


### PR DESCRIPTION
## Changes

- In most places, empty `<style />` was accounted for.
- In `preprocessStyle`, we were unconditionally accessing the `FirstChild`.
- Added a WASM test for this, since that's the only way to hit this case.

## Testing

JS/WASM test added

## Docs

Bug fix only
